### PR TITLE
Fixed plugin i18n issue

### DIFF
--- a/dpwap-Class.php
+++ b/dpwap-Class.php
@@ -324,7 +324,11 @@ class dpwapuploader
 				}
 			}
 			else{
-			_e('This is <b>'.$dpwap_locFilenm.'</b> not a valid zip archive.','mpi');
+			printf(
+				/* translators: Name of the file */
+				__( '<b>%s</b> is not a valid zip archive.', 'mpi' ),
+				$dpwap_locFilenm
+			); 
 			}
 		}
 		if($dpwap_tempurls)


### PR DESCRIPTION
The issue with this string is that you’re using a variable inside a translation function. This is not allowed and should to be fixed in order to avoid issues with the GlotPress parsing (the WordPress.org translation platform). More info: https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#variables